### PR TITLE
Fixed some coreference bugs

### DIFF
--- a/src/com/ontological/retrieval/Utilities/Models.java
+++ b/src/com/ontological/retrieval/Utilities/Models.java
@@ -15,6 +15,9 @@ public class Models
     static final String PR_IT = "IT";
     static final String PR_THEY = "THEY";
 
+    static final String PR_THAT = "THAT";
+    static final String PR_THEM = "THEM";
+
     static HashMap<Integer,String> m_PronounModel;
 
     public static boolean isPronoun( String word ) {
@@ -26,7 +29,15 @@ public class Models
             m_PronounModel.put( PR_SHE.hashCode(), PR_SHE );
             m_PronounModel.put( PR_IT.hashCode(), PR_IT );
             m_PronounModel.put( PR_THEY.hashCode(), PR_THEY );
+            m_PronounModel.put( PR_THAT.hashCode(), PR_THAT );
+            m_PronounModel.put( PR_THEM.hashCode(), PR_THEM );
         }
         return m_PronounModel.containsKey( word.toUpperCase().hashCode() );
+    }
+
+    //
+    // This a special kind of a Pronoun which very often is placed in a current sentence.
+    public static boolean isPositionedPronoun( String word ) {
+        return word.toUpperCase().equals( PR_THAT );
     }
 }

--- a/src/com/ontological/retrieval/Utilities/Neo4j/GenerateGraph.java
+++ b/src/com/ontological/retrieval/Utilities/Neo4j/GenerateGraph.java
@@ -9,13 +9,16 @@ import java.util.*;
 /**
  * @author Dmitry Scherbakov
  * @email  dm.scherbakov[_d0g_]yandex.ru
+ *
+ * @brief The results could be visualized on the site http://console.neo4j.org/
+ *        For that use Cypher syntax.
  */
 public class GenerateGraph
 {
     private GenerateGraph(){}
-    //
-    // The results could be visualized on the site http://console.neo4j.org/
-    // For that use Cypher syntax.
+    /**
+     * @brief Generate a script for modeling Sentence semantic structure
+     */
     public static String generateSentenceGraph(List<Entity> entitiesIndex )
     {
         String sentenceGraph = new String();
@@ -46,6 +49,9 @@ public class GenerateGraph
         return sentenceGraph;
     }
 
+    /**
+     * @brief Generate a script for modeling the full triplets connected structure.
+     */
     public static String generateTripletsGraph(List<Triplet> triplets )
     {
         String graph = "";
@@ -64,9 +70,9 @@ public class GenerateGraph
                 nodes.put( subjectId, getSubjectLemma( triplet ) );
             }
 
-            if ( triplet.isValid() && triplet.isRelation() ) {
-                String rel = String.format( "_%s-[:%s]->_%s", subjectId, triplet.getRelation(), objectId );
-                edges.add( rel );
+            if ( triplet.isValid() ) {
+                String rel = String.format("_%s-[:%s]->_%s", subjectId, triplet.getRelation(), objectId);
+                edges.add(rel);
             }
         }
         Iterator it = nodes.entrySet().iterator();
@@ -87,6 +93,11 @@ public class GenerateGraph
         return graph;
     }
 
+    /**
+     * @inner
+     * @todo
+     *      Move to utils or to a class TripletObject
+     */
     private static String getObjectLemma( Triplet triplet ){
         if ( triplet.getObjectCoref() != null ) {
             if ( triplet.getObjectCoref().getLemma() != null ) {
@@ -103,6 +114,11 @@ public class GenerateGraph
         }
     }
 
+    /**
+     * @inner
+     * @todo
+     *      Move to utils or to a class TripletSubject
+     */
     private static String getSubjectLemma( Triplet triplet ){
         if ( triplet.getSubjectCoref() != null ) {
             if ( triplet.getSubjectCoref().getLemma() != null ) {

--- a/src/com/ontological/retrieval/Utilities/Triplet.java
+++ b/src/com/ontological/retrieval/Utilities/Triplet.java
@@ -86,6 +86,7 @@ public class Triplet extends Annotation
         if ( m_SubjectCoref == null ) {
             m_SubjectId = Utils.TokenHash( m_Subject );
         }
+
     }
     public void setRelation( String relation ) {
         m_Relation = relation;
@@ -153,7 +154,7 @@ public class Triplet extends Annotation
     }
 
     public boolean isValid() {
-        return isObject() && isObject() && isRelation();
+        return isObject() && isSubject() && isRelation();
     }
 
     /**
@@ -174,19 +175,21 @@ public class Triplet extends Annotation
         cl.setObject( m_Object );
         cl.setSubject( m_Subject );
         cl.setRelation( m_Relation );
-        cl.addObjectAttrs( m_ObjectAttrs );
-        cl.addSubjectAttrs( m_SubjectAttrs );
+        if ( m_ObjectAttrs != null ) {
+            cl.addObjectAttrs( m_ObjectAttrs );
+        }
+        if ( m_SubjectAttrs != null ) {
+            cl.addSubjectAttrs( m_SubjectAttrs );
+        }
         cl.setScore( m_Score );
         return cl;
     }
-    public void printShort() {
-        System.out.printf( "[ short_triplet ] < %s > :%s < %s >\n", m_Subject == null ? "" : m_Subject.getCoveredText(),
-                m_Relation, m_Object == null ? "" : m_Object.getCoveredText() );
-    }
     public void printShortCoref() {
-        System.out.printf( "[ short_coref_triplet ] < %s > :%s < %s >\n",
-                m_SubjectCoref == null ? ( isSubject() ? m_Subject.getCoveredText() : "" ) : "coref$" + m_SubjectCoref.getCoveredText(),
-                m_Relation,
-                m_ObjectCoref == null ? ( isObject() ? m_Object.getCoveredText() : "" ) : "coref$" + m_ObjectCoref.getCoveredText() );
+        String sbj = m_SubjectCoref == null ? ( isSubject() ? m_Subject.getCoveredText() : "" ) : "coref$" + m_SubjectCoref.getCoveredText();
+        String obj = m_ObjectCoref == null ? ( isObject() ? m_Object.getCoveredText() : "" ) : "coref$" + m_ObjectCoref.getCoveredText();
+        String sbjPosVal = sbj.isEmpty() ? "" : (m_SubjectCoref == null ? m_Subject.getPos().getPosValue() : m_SubjectCoref.getPos().getPosValue());
+        String objPosVal = obj.isEmpty() ? "" : (m_ObjectCoref == null ? m_Object.getPos().getPosValue() : m_ObjectCoref.getPos().getPosValue());
+        System.out.printf( "[ short_coref_triplet ] < %s >/%s/ :%s < %s >/%s/\n",
+                sbj,sbjPosVal,m_Relation, obj, objPosVal);
     }
 }

--- a/src/com/ontological/retrieval/Utilities/Utils.java
+++ b/src/com/ontological/retrieval/Utilities/Utils.java
@@ -10,7 +10,7 @@ import org.springframework.util.DigestUtils;
 public class Utils
 {
     public static String TokenHash( Token tk ) {
-        if ( tk.getLemma() == null || tk.getLemma().getValue().isEmpty() ) {
+        if ( tk == null || tk.getLemma() == null || tk.getLemma().getValue().isEmpty() ) {
             return Constants.INVALID_HASH;
         }
         return DigestUtils.md5DigestAsHex( tk.getLemma().getValue().getBytes() );


### PR DESCRIPTION
Fixed:
- The coreference of pronoun word  'that' was resolved (withing the scope of current sentence and previous).
- Added filtering for `subject` and `object` fields by POS info.
- Fixed a bug of `Triplet.isValid( )` function.
- Some minor fixes.
