### PR TITLE
Triplets extraction improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/target/
 src/scripts/
 target/
 results/*
+samples/tmp/

--- a/src/com/ontological/retrieval/AnalysisEngines/SimpleAnswerMatcher.java
+++ b/src/com/ontological/retrieval/AnalysisEngines/SimpleAnswerMatcher.java
@@ -3,6 +3,7 @@ package com.ontological.retrieval.AnalysisEngines;
 import com.ontological.retrieval.Utilities.Models;
 import com.ontological.retrieval.DataTypes.Question;
 import com.ontological.retrieval.DataTypes.Triplet;
+import com.ontological.retrieval.Utilities.Utils;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.fit.component.JCasConsumer_ImplBase;
@@ -56,9 +57,8 @@ public class SimpleAnswerMatcher extends JCasConsumer_ImplBase
                         if ( !candidate.isValid() ) {
                             continue;
                         }
-                        candidate.print();
                         String candidateObject = candidate.getObject().getField().getLemma().getValue();
-                        if (    candidate.getRelation().equals( question.getRelation() ) &&
+                        if (    Utils.isRelationsCompatible( candidate, question ) &&
                                 candidateObject.equals( question.getObject() ) ) {
                             answers.add( candidate );
                             ++count;
@@ -69,14 +69,13 @@ public class SimpleAnswerMatcher extends JCasConsumer_ImplBase
                             break;
                         }
                     }
-                } else if ( Models.PR_WHAT.equals( question.getSubject().toUpperCase() ) ) {
+                } else if ( Models.PR_WHAT.equals( question.getSubject().toUpperCase() ) || Models.PR_WHICH.equals( question.getSubject().toUpperCase() ) ) {
                     for ( Triplet candidate : triplets ) {
                         if ( !candidate.isValid() ) {
                             continue;
                         }
-                        candidate.print();
                         String candidateSubject = candidate.getSubject().getField().getLemma().getValue();
-                        if (    candidate.getRelation().equals( question.getRelation() ) &&
+                        if (    Utils.isRelationsCompatible( candidate, question ) &&
                                 candidateSubject.equals( question.getObject() ) ) {
                             answers.add( candidate );
                             ++count;
@@ -92,7 +91,7 @@ public class SimpleAnswerMatcher extends JCasConsumer_ImplBase
         }
         System.out.println( "Answers: =>");
         for ( Triplet ansTriplet : answers ) {
-            System.out.println( ansTriplet.getContext() );
+            System.out.println( ansTriplet.getContext().getCoveredText() );
             ansTriplet.print();
         }
         System.out.println( "<=");

--- a/src/com/ontological/retrieval/AnalysisEngines/TripletsExtractor.java
+++ b/src/com/ontological/retrieval/AnalysisEngines/TripletsExtractor.java
@@ -169,7 +169,9 @@ public class TripletsExtractor extends AbstractTripletsAnalyzer
                 object.setFieldCoref( corefDonor.getSubject().getField() );
             }
         }
-
+        //
+        // Cross validation for subject coreference
+        //
         if ( subject != null && subject.isValid() && !subject.isCoreference() && Models.isPronoun( triplet.getSubject().getCoveredText() ) ) {
             if ( Models.isPositionedPronoun( triplet.getSubject().getCoveredText() ) ) {
                 //
@@ -186,6 +188,29 @@ public class TripletsExtractor extends AbstractTripletsAnalyzer
                     Triplet donorTriplet = tripletsList.get( tripletsList.size() - 1 );
                     if ( donorTriplet.getScore().getMainPointsCount() <= 2 ) {
                         subject.setFieldCoref( donorTriplet.getSubject().getField() );
+                    }
+                }
+            }
+        }
+        //
+        // Cross validation for object coreference
+        //
+        if ( object != null && object.isValid() && !object.isCoreference() && Models.isPronoun( triplet.getObject().getCoveredText() ) ) {
+            if ( Models.isPositionedPronoun( triplet.getObject().getCoveredText() ) ) {
+                //
+                // Some pronouns should searched in a current sentence.
+                // The example of such pronoun is 'that'.
+                //
+                if ( prevTr_InCurrSent != null ) {
+                    TripletField prev = prevTr_InCurrSent.getSubject();
+                    object.setFieldCoref( prev.getField() );
+                }
+            } else if ( prevSentence != null ) {
+                List<Triplet> tripletsList = JCasUtil.selectCovered( aJCas, Triplet.class, prevSentence );
+                if ( tripletsList != null && tripletsList.size() > 0 ) {
+                    Triplet donorTriplet = tripletsList.get( tripletsList.size() - 1 );
+                    if ( donorTriplet.getScore().getMainPointsCount() <= 2 ) {
+                        object.setFieldCoref( donorTriplet.getSubject().getField() );
                     }
                 }
             }

--- a/src/com/ontological/retrieval/AnalysisEngines/TripletsWriter.java
+++ b/src/com/ontological/retrieval/AnalysisEngines/TripletsWriter.java
@@ -45,6 +45,7 @@ public class TripletsWriter extends JCasConsumer_ImplBase
         try {
             writeTripletsGraph( aJCas );
             writeSentenceSemantic( aJCas );
+            writeTriplets( aJCas );
         } catch ( UnsupportedEncodingException ex ) {
             ex.printStackTrace();
         } catch ( FileNotFoundException ex ) {
@@ -78,6 +79,16 @@ public class TripletsWriter extends JCasConsumer_ImplBase
         if ( out.size() > 0 ) {
             try ( PrintWriter writer = new PrintWriter( senteceSemanticPath, FILE_ENCODING ) ) {
                 writer.write( Utils.listOfStringToString( out, "\n" ) );
+            }
+        }
+    }
+
+    private void writeTriplets( JCas aJCas ) {
+        for ( Sentence sentence : JCasUtil.select( aJCas, Sentence.class ) ) {
+            System.out.println( "Sentence: " + sentence.getCoveredText() );
+            for ( Triplet tr : JCasUtil.selectCovered( aJCas, Triplet.class, sentence ) ) {
+                tr.print();
+                System.out.println();
             }
         }
     }

--- a/src/com/ontological/retrieval/DataTypes/Question.java
+++ b/src/com/ontological/retrieval/DataTypes/Question.java
@@ -1,5 +1,11 @@
 package com.ontological.retrieval.DataTypes;
 
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 /**
  * @author Dmitry Scherbakov
  * @email  dm.scherbakov@yandex.ru
@@ -8,15 +14,15 @@ public class Question
 {
     private String m_Subject;
     private String m_Object;
-    private String m_Relation;
+    private HashMap<String, List<String>> m_Relations;
     // The raw question itself
     private String m_Context;
 
     public Question( Triplet triplet ) {
         m_Subject = triplet.getSubject().getField().getLemma().getValue();
         m_Object = triplet.getObject().getField().getLemma().getValue();
-        m_Relation = triplet.getRelation();
         m_Context = triplet.getContext().getCoveredText();
+        copyRelations( triplet );
     }
 
     public String getSubject() {
@@ -27,8 +33,14 @@ public class Question
         return m_Object;
     }
 
-    public String getRelation() {
-        return m_Relation;
+    public List<String> getRelations( String dependency ) {
+        return m_Relations.get( dependency );
+    }
+
+    public List<String> getRelationTypes() {
+        List<String> types = new ArrayList<>();
+        types.addAll( m_Relations.keySet() );
+        return types;
     }
 
     public String getContext() {
@@ -36,6 +48,34 @@ public class Question
     }
 
     public void print() {
-        System.out.printf( "[question]: %s\n\t\t<%s> /%s/ <%s>\n", m_Context, m_Subject, m_Relation, m_Object );
+        System.out.printf( "[question]: %s\n\t\t<%s> /%s/ <%s>\n", m_Context, m_Subject, formattedRelations(), m_Object );
+    }
+
+    private void copyRelations( Triplet triplet ) {
+        if ( triplet.isRelation() ) {
+            m_Relations = new HashMap<>();
+            for ( String dependency : triplet.getRelationTypes() ) {
+                List<String> rels = new ArrayList<>();
+                for ( Token relation : triplet.getRelations( dependency ) ) {
+                    rels.add( relation.getLemma().getValue() );
+                }
+                m_Relations.put( dependency, rels );
+            }
+        }
+    }
+
+    private String formattedRelations() {
+        String relation = "";
+        if ( m_Relations != null && !m_Relations.isEmpty() ) {
+            for ( String dependency : getRelationTypes() ) {
+                relation = relation + "{" + dependency + ":";
+                String deepRelations = "";
+                for ( String rel : m_Relations.get( dependency ) ) {
+                    deepRelations = deepRelations + ", " + rel;
+                }
+                relation = relation + deepRelations + "}";
+            }
+        }
+        return relation;
     }
 }

--- a/src/com/ontological/retrieval/DataTypes/Triplet.java
+++ b/src/com/ontological/retrieval/DataTypes/Triplet.java
@@ -1,11 +1,16 @@
 package com.ontological.retrieval.DataTypes;
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import org.apache.uima.cas.CASException;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.JCasRegistry;
 import org.apache.uima.jcas.cas.TOP_Type;
 import org.apache.uima.jcas.tcas.Annotation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * @author Dmitry Scherbakov
@@ -26,7 +31,7 @@ public class Triplet extends Annotation
     private TripletField m_Subject;
     private TripletField m_Object;
 
-    private String m_Relation;
+    private HashMap<String, List<Token>> m_Relations;
 
     private Sentence m_Context;
 
@@ -51,8 +56,16 @@ public class Triplet extends Annotation
         m_Subject = subject;
     }
 
-    public void setRelation( String relation ) {
-        m_Relation = relation;
+    public void addRelation( String dep, Token relation ) {
+        if ( m_Relations == null ) {
+            m_Relations = new HashMap<>();
+        }
+        List<Token> currentRelations = m_Relations.get( dep );
+        if ( currentRelations == null ) {
+            currentRelations = new ArrayList<>();
+            m_Relations.put( dep, currentRelations );
+        }
+        currentRelations.add( relation );
     }
 
     public void setScore( TripletScore score ) {
@@ -67,8 +80,14 @@ public class Triplet extends Annotation
         return m_Subject;
     }
 
-    public String getRelation() {
-        return m_Relation;
+    public List<Token> getRelations( String dep ) {
+        return m_Relations.get( dep );
+    }
+
+    public List<String> getRelationTypes() {
+        List<String> list = new ArrayList<>();
+        list.addAll( m_Relations.keySet() );
+        return list;
     }
 
     public TripletScore getScore() {
@@ -80,7 +99,7 @@ public class Triplet extends Annotation
     }
 
     public boolean isRelation() {
-        return m_Relation != null && !m_Relation.isEmpty();
+        return m_Relations != null && !m_Relations.isEmpty();
     }
 
     public boolean isValid() {
@@ -91,10 +110,15 @@ public class Triplet extends Annotation
     public Triplet clone() {
         try {
             Triplet triplet = new Triplet( getCAS().getJCas(), m_Context );
-            triplet.setRelation( m_Relation );
             triplet.setSubject( m_Subject.clone() );
             triplet.setObject( m_Object.clone() );
             triplet.setScore( m_Score );
+            if ( isRelation() ) {
+                triplet.m_Relations = new HashMap<>();
+                for ( String dep : getRelationTypes() ) {
+                    triplet.m_Relations.put( dep, m_Relations.get( dep ) );
+                }
+            }
             return triplet;
         } catch ( CASException ex ) {
             return null;
@@ -107,8 +131,55 @@ public class Triplet extends Annotation
         String sbjPosVal = ( m_Subject == null ? "" : m_Subject.getField().getPos().getPosValue() );
         String objPosVal = ( m_Object == null ? "" : m_Object.getField().getPos().getPosValue() );
 
-        System.out.printf( "[triplet] <%s%s>/%s/ :%s <%s%s>/%s/\n",
-                subject, ( m_Subject != null && m_Subject.isCoreference() ? "$coref" : "" ), sbjPosVal,m_Relation,
+        System.out.printf( "[triplet] <%s%s>/%s/ _:%s <%s%s>/%s/\n",
+                subject, ( m_Subject != null && m_Subject.isCoreference() ? "$coref" : "" ), sbjPosVal,formattedRelations(),
                 object, ( m_Object != null && m_Object.isCoreference() ? "$coref" : "" ), objPosVal);
+
+        //
+        // @todo
+        //      Add check for PoS: it must be adjective or noun.
+        //
+        String subjectAttributes = "";
+        String objectAttributes = "";
+        if ( getObject() != null ) {
+            for ( Token tk : getObject().getAttributes( TripletField.AttributeType.DESCRIPTION_ENTITY ) ) {
+                if ( !subjectAttributes.isEmpty() ) {
+                    subjectAttributes += ',';
+                }
+                subjectAttributes += tk.getCoveredText();
+            }
+        }
+        if ( getSubject() != null ) {
+            for ( Token tk : getSubject().getAttributes( TripletField.AttributeType.DESCRIPTION_ENTITY ) ) {
+                if ( !objectAttributes.isEmpty() ) {
+                    objectAttributes += ',';
+                }
+                objectAttributes += tk.getCoveredText();
+            }
+        }
+        if ( !subjectAttributes.isEmpty() ) {
+            System.out.println( "$ Subject attributes: " + subjectAttributes );
+        }
+        if ( !objectAttributes.isEmpty() ) {
+            System.out.println( "$ Object attributes: " + objectAttributes );
+        }
+    }
+
+    public String formattedRelations() {
+        String relation = "";
+        if ( isRelation() ) {
+            for ( String dependency : getRelationTypes() ) {
+                relation = relation + "{" + dependency + ":";
+                String deepRelations = "";
+                for ( Token rel : m_Relations.get( dependency ) ) {
+                    if ( !deepRelations.isEmpty() ) {
+                        deepRelations += ',';
+                    }
+                    deepRelations += rel.getCoveredText();
+                }
+                relation = relation + deepRelations + "}";
+            }
+        }
+        return '[' + relation + ']';
     }
 }

--- a/src/com/ontological/retrieval/DataTypes/TripletField.java
+++ b/src/com/ontological/retrieval/DataTypes/TripletField.java
@@ -30,6 +30,7 @@ public class TripletField extends Annotation
 
     public static enum AttributeType {
         NAMED_ENTITY,
+        DESCRIPTION_ENTITY, // mostly, it is an 'adjective' entity.
         ABSTRACT_ENTITY,
 
         LAST
@@ -55,6 +56,7 @@ public class TripletField extends Annotation
         m_FieldId = Utils.TokenHash( m_FieldCoref );
 
         m_Attributes.put( AttributeType.NAMED_ENTITY, new ArrayList<>() );
+        m_Attributes.put( AttributeType.DESCRIPTION_ENTITY, new ArrayList<>() );
         m_Attributes.put( AttributeType.ABSTRACT_ENTITY, new ArrayList<>() );
     }
 

--- a/src/com/ontological/retrieval/Main.java
+++ b/src/com/ontological/retrieval/Main.java
@@ -21,7 +21,11 @@ public class Main {
 
 //    private static String DOCUMENT_PATH_ENG = "samples/en/encyclopedia/Angora-Goats.txt";
     private static String DOCUMENT_PATH_ENG = "samples/en/simple-pen.txt";
-    private static String QUESTIONS_PATH_ENG = "samples/en/questions/simple-pen-q.txt";
+//    private static String DOCUMENT_PATH_ENG = "samples/tmp/cpp.txt";
+//    private static String DOCUMENT_PATH_ENG = "samples/tmp/drm.txt";
+//    private static String QUESTIONS_PATH_ENG = "samples/en/questions/simple-pen-q.txt";
+    private static String QUESTIONS_PATH_ENG = "samples/tmp/drm_q.txt";
+//    private static String QUESTIONS_PATH_ENG = "samples/tmp/q_cpp.txt"
 //    private static String DOCUMENT_PATH_ENG = "samples/en/complicated-pen.txt";
     private static String DOCUMENT_PATH_RUS = "samples/ru/walt-disney-ru.txt";
 
@@ -73,7 +77,7 @@ public class Main {
                 createEngineDescription( StanfordLemmatizer.class ),
                 createEngineDescription( StanfordParser.class, StanfordParser.PARAM_MODE, StanfordParser.DependenciesMode.TREE ),
                 createEngineDescription( StanfordCoreferenceResolver.class ),
-                createEngineDescription( StanfordNamedEntityRecognizer.class ),
+//                createEngineDescription( StanfordNamedEntityRecognizer.class ),
                 createEngineDescription( TripletsExtractor.class, TripletsExtractor.PARAM_FACTOR, TripletsExtractor.TripletValidationFactor.ALL ),
                 createEngineDescription( TripletsWriter.class,
                         TripletsWriter.PARAM_TRIPLET_PATH, TripletsWriter.DEFAULT_TRIPLETS_PATH,

--- a/src/com/ontological/retrieval/Utilities/Models.java
+++ b/src/com/ontological/retrieval/Utilities/Models.java
@@ -20,6 +20,7 @@ public class Models
     public static final String PR_WHO = "WHO";
 
     public static final String PR_WHAT = "WHAT";
+    public static final String PR_WHICH = "WHICH";
 
     static HashMap<Integer,String> m_PronounModel;
 

--- a/src/com/ontological/retrieval/Utilities/Neo4j/GenerateGraph.java
+++ b/src/com/ontological/retrieval/Utilities/Neo4j/GenerateGraph.java
@@ -30,7 +30,7 @@ public class GenerateGraph
                 nodes.add( nd );
                 Entity parent = entity.getParent();
                 if ( parent != null ) {
-                    String rel = String.format( "_%d-[:%s]->_%d", entity.getBegin(), entity.getType(), parent.getBegin() );
+                    String rel = String.format( "(_%d)-[:%s]->(_%d)", entity.getBegin(), entity.getType(), parent.getBegin() );
                     relations.add( rel );
                 }
             }
@@ -71,7 +71,7 @@ public class GenerateGraph
             }
 
             if ( triplet.isValid() ) {
-                String rel = String.format("_%s-[:%s]->_%s", subjectId, triplet.getRelation(), objectId);
+                String rel = String.format("(_%s)-[:%s]->(_%s)", subjectId, triplet.formattedRelations(), objectId);
                 edges.add(rel);
             }
         }

--- a/src/com/ontological/retrieval/Utilities/Utils.java
+++ b/src/com/ontological/retrieval/Utilities/Utils.java
@@ -1,6 +1,7 @@
 package com.ontological.retrieval.Utilities;
 
 import com.ontological.retrieval.DataTypes.Entity;
+import com.ontological.retrieval.DataTypes.Question;
 import com.ontological.retrieval.DataTypes.Triplet;
 import com.ontological.retrieval.DataTypes.TripletField;
 import de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceLink;
@@ -74,6 +75,16 @@ public class Utils
         return null;
     }
 
+    public static List<Entity> findEntitiesType( String type, List<Entity> entities  ) {
+        List<Entity> localEntities = new ArrayList<>();
+        for ( Entity en : entities ) {
+            if ( en.getType().equals( type ) ) {
+                localEntities.add( en );
+            }
+        }
+        return localEntities;
+    }
+
     public static boolean isNoun( Token tk ) {
         String text = tk.getCoveredText().toUpperCase();
         boolean isSingleValid = !text.equals( 'I' ) && text.length() == 1;
@@ -119,5 +130,20 @@ public class Utils
             out = out + element + separator;
         }
         return out;
+    }
+
+    public static boolean isRelationsCompatible( Triplet triplet, Question question ) {
+        for ( String qDependency : question.getRelationTypes() ) {
+            for ( String qRelation : question.getRelations( qDependency ) ) {
+                for ( String trDependency : triplet.getRelationTypes() ) {
+                    for ( Token trRelation : triplet.getRelations( trDependency ) ) {
+                        if ( trRelation.getLemma().getValue().toLowerCase().equals( qRelation ) ) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- Modified `relation` field structure of triplets. Now, it is parametric and could contain multiple relation entities (e.g. `could not write`). Each relation will be saved with the dependency information. This dependency is a key for a partucular relation.
- Improved coreference resolver alrorithm.
- Added one more targer for parsing sentence (e.g. now, extraction multiple triplets from a single sentence -- increased).
- Added parametrization for subject/object fields of triplets. Now, Triplet contain information about such characteristic as: color, size, mind, width and so on (adjective parametrization).
