### PR TITLE
Implementation of object-definition-context

### DIFF
--- a/src/com/ontological/retrieval/AnalysisEngines/AbstractTripletsAnalyzer.java
+++ b/src/com/ontological/retrieval/AnalysisEngines/AbstractTripletsAnalyzer.java
@@ -44,6 +44,7 @@ abstract public class AbstractTripletsAnalyzer extends JCasConsumer_ImplBase
                 triplet.addRelation( innerEntity.getType(), innerEntity.getName() );
             }
             triplet.addRelation( entity.getType(), entity.getParent().getName() );
+            Utils.parseDefinition( triplet, entity.getParent() );
         } else if( entity.getType().equals( "NSUBJ" ) ) {
             triplet = new Triplet( aJCas, sentence );
             TripletField subjectField = new TripletField( aJCas, entity.getName() );
@@ -55,10 +56,12 @@ abstract public class AbstractTripletsAnalyzer extends JCasConsumer_ImplBase
                 Utils.parseProperties( objectField, dobjEntity );
                 triplet.setObject( objectField );
                 triplet.addRelation( dobjEntity.getType(), entity.getParent().getName() );
+                Utils.parseDefinition( triplet, dobjEntity );
             } else if ( Utils.isNoun( entity.getParent() ) || Utils.isAdjective( entity.getParent() ) ) {
                 TripletField objectField = new TripletField( aJCas, entity.getParent().getName() );
                 Utils.parseProperties( objectField, entity.getParent() );
                 triplet.setObject( objectField );
+                Utils.parseDefinition( triplet, entity.getParent() );
             }
             //
             // fill multiple relations
@@ -75,6 +78,7 @@ abstract public class AbstractTripletsAnalyzer extends JCasConsumer_ImplBase
                 // It is a boosting for determination of relation type. Primary it MUST be 'entity.getParent().getType()'
                 String relation = ( entity.getParent().getType() == null ? entity.getType() : entity.getParent().getType() );
                 triplet.addRelation( relation, entity.getParent().getName() );
+                Utils.parseDefinition( triplet, entity.getParent() );
             }
         } else if ( entity.getType().equals( "CONJ" ) ) {
             if ( entity.getName().getPos().getPosValue().equals( "VBD" ) || entity.getName().getPos().getPosValue().equals( "VB" ) ) {

--- a/src/com/ontological/retrieval/DataTypes/Triplet.java
+++ b/src/com/ontological/retrieval/DataTypes/Triplet.java
@@ -30,6 +30,7 @@ public class Triplet extends Annotation
 
     private TripletField m_Subject;
     private TripletField m_Object;
+    private String m_Definition;
 
     private HashMap<String, List<Token>> m_Relations;
 
@@ -70,6 +71,10 @@ public class Triplet extends Annotation
 
     public void setScore( TripletScore score ) {
         m_Score = score;
+    }
+
+    public void setDefinition( String definition ) {
+        m_Definition = definition;
     }
 
     public TripletField getObject() {
@@ -158,10 +163,13 @@ public class Triplet extends Annotation
             }
         }
         if ( !subjectAttributes.isEmpty() ) {
-            System.out.println( "$ Subject attributes: [" + subjectAttributes + ']' );
+            System.out.println( "\t$ Subject attributes: [" + subjectAttributes + ']' );
         }
         if ( !objectAttributes.isEmpty() ) {
-            System.out.println( "$ Object attributes: [" + objectAttributes + ']' );
+            System.out.println( "\t$ Object attributes: [" + objectAttributes + ']' );
+        }
+        if ( m_Definition != null ) {
+            System.out.println( "\tDefinition: " + m_Definition );
         }
     }
 


### PR DESCRIPTION
Implemented parametrization of object-definition-context. Example:

```
Sentence: The animals were used for production of meat, milk, skins, and fiber.
[triplet] <animal>/NNS/ _:[{AUXPASS:were}{NSUBJPASS:used}] <>//
    Definition: for production of meat, milk, skins, and fiber
```

Definition field is object-definition-context.
