### PR TITLE
Implementation of Named Entity assignment to Triplets fields.

### DIFF
--- a/src/com/ontological/retrieval/AnalysisEngines/TripletsWriter.java
+++ b/src/com/ontological/retrieval/AnalysisEngines/TripletsWriter.java
@@ -45,7 +45,7 @@ public class TripletsWriter extends JCasConsumer_ImplBase
         try {
             writeTripletsGraph( aJCas );
             writeSentenceSemantic( aJCas );
-            writeTriplets( aJCas );
+//            writeTriplets( aJCas );
         } catch ( UnsupportedEncodingException ex ) {
             ex.printStackTrace();
         } catch ( FileNotFoundException ex ) {

--- a/src/com/ontological/retrieval/DataTypes/Triplet.java
+++ b/src/com/ontological/retrieval/DataTypes/Triplet.java
@@ -147,7 +147,8 @@ public class Triplet extends Annotation
         String subjectAttributes = "";
         String objectAttributes = "";
         if ( getObject() != null ) {
-            for ( Token tk : getObject().getAttributes( TripletField.AttributeType.DESCRIPTION_ENTITY ) ) {
+            for ( Object obj : getObject().getAttributes( TripletField.AttributeType.DESCRIPTION_ENTITY ) ) {
+                Token tk = (Token)obj;
                 if ( !objectAttributes.isEmpty() ) {
                     objectAttributes += ',';
                 }
@@ -155,7 +156,8 @@ public class Triplet extends Annotation
             }
         }
         if ( getSubject() != null ) {
-            for ( Token tk : getSubject().getAttributes( TripletField.AttributeType.DESCRIPTION_ENTITY ) ) {
+            for ( Object obj : getSubject().getAttributes( TripletField.AttributeType.DESCRIPTION_ENTITY ) ) {
+                Token tk = (Token)obj;
                 if ( !subjectAttributes.isEmpty() ) {
                     subjectAttributes += ',';
                 }

--- a/src/com/ontological/retrieval/DataTypes/TripletField.java
+++ b/src/com/ontological/retrieval/DataTypes/TripletField.java
@@ -31,12 +31,10 @@ public class TripletField extends Annotation
     public static enum AttributeType {
         NAMED_ENTITY,
         DESCRIPTION_ENTITY, // mostly, it is an 'adjective' entity.
-        ABSTRACT_ENTITY,
-
-        LAST
+        ABSTRACT_ENTITY
     }
 
-    private HashMap<AttributeType, List<Token>> m_Attributes = new HashMap<>();
+    private HashMap<AttributeType, List<Object>> m_Attributes = new HashMap<>();
 
     private Token m_Field;
     private Token m_FieldCoref;
@@ -55,17 +53,17 @@ public class TripletField extends Annotation
         m_Field = token;
         m_FieldId = Utils.TokenHash( m_Field );
 
-        m_Attributes.put( AttributeType.NAMED_ENTITY, new ArrayList<>() );
-        m_Attributes.put( AttributeType.DESCRIPTION_ENTITY, new ArrayList<>() );
-        m_Attributes.put( AttributeType.ABSTRACT_ENTITY, new ArrayList<>() );
+        for ( AttributeType type : AttributeType.values() ) {
+            m_Attributes.put( type, new ArrayList<>() );
+        }
     }
 
-    public void addAttribute( AttributeType type, Token attribute ) {
-        List<Token> attributes = m_Attributes.get( type );
+    public void addAttribute( AttributeType type, Object attribute ) {
+        List<Object> attributes = m_Attributes.get( type );
         attributes.add( attribute );
     }
 
-    public List<Token> getAttributes( AttributeType type ) {
+    public List<Object> getAttributes( AttributeType type ) {
         return m_Attributes.get( type );
     }
 
@@ -116,17 +114,10 @@ public class TripletField extends Annotation
             if ( isCoreference() ) {
                 field.setFieldCoref( m_FieldCoref );
             }
-            List<Token> nes = getAttributes( AttributeType.NAMED_ENTITY );
-            for( Token entity : nes ) {
-                field.addAttribute( AttributeType.NAMED_ENTITY, entity );
-            }
-            List<Token> desc = getAttributes( AttributeType.DESCRIPTION_ENTITY );
-            for( Token entity : desc ) {
-                field.addAttribute( AttributeType.DESCRIPTION_ENTITY, entity );
-            }
-            List<Token> abstr = getAttributes( AttributeType.ABSTRACT_ENTITY );
-            for( Token entity : abstr ) {
-                field.addAttribute( AttributeType.ABSTRACT_ENTITY, entity );
+            for ( AttributeType type : AttributeType.values() ) {
+                for ( Object entity : getAttributes( type ) ) {
+                    field.addAttribute( type, entity );
+                }
             }
             return field;
         } catch ( CASException ex ) {

--- a/src/com/ontological/retrieval/Main.java
+++ b/src/com/ontological/retrieval/Main.java
@@ -79,7 +79,7 @@ public class Main {
                 createEngineDescription( StanfordLemmatizer.class ),
                 createEngineDescription( StanfordParser.class, StanfordParser.PARAM_MODE, StanfordParser.DependenciesMode.TREE ),
                 createEngineDescription( StanfordCoreferenceResolver.class ),
-//                createEngineDescription( StanfordNamedEntityRecognizer.class ),
+                createEngineDescription( StanfordNamedEntityRecognizer.class ),
                 createEngineDescription( TripletsExtractor.class, TripletsExtractor.PARAM_FACTOR, TripletsExtractor.TripletValidationFactor.ALL ),
                 createEngineDescription( TripletsWriter.class,
                         TripletsWriter.PARAM_TRIPLET_PATH, TripletsWriter.DEFAULT_TRIPLETS_PATH,

--- a/src/com/ontological/retrieval/Utilities/Constants.java
+++ b/src/com/ontological/retrieval/Utilities/Constants.java
@@ -8,4 +8,8 @@ public class Constants
 {
     public static final int INVALID_VALUE = -1;
     public static final String INVALID_HASH = String.format( "%d", Constants.INVALID_VALUE );
+
+    public static final String PERSON = "PERSON";
+    public static final String LOCATION = "LOCATION";
+    public static final String ORGANIZATION = "ORGANIZATION";
 }

--- a/src/com/resources/desc/type/TripletField_conf.xml
+++ b/src/com/resources/desc/type/TripletField_conf.xml
@@ -12,7 +12,6 @@
                 <featureDescription>
                     <name>attributes</name>
                     <rangeTypeName>uima.cas.FSList</rangeTypeName>
-                    <elementType>de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token</elementType>
                 </featureDescription>
 				<featureDescription>
                     <name>setFieldCoref</name>


### PR DESCRIPTION
In case of existing named entity in the intersected context with Triplets fields, these Named Entities will be saved as the attributes of the matched Triplet fields. Example:

```
Sentecnce: North Park is located in the bigest city
<Park>/NN/ _:[is,located] <>/ /
Subject named entity: North Park / LOCATION
```

**Note**: named entities assignment is not implemented for Triplet definition field (will be done latter).
