### PR TITLE
Modified named entities for assignment to Triplet definition

### DIFF
--- a/src/com/ontological/retrieval/AnalysisEngines/TripletsExtractor.java
+++ b/src/com/ontological/retrieval/AnalysisEngines/TripletsExtractor.java
@@ -1,9 +1,6 @@
 package com.ontological.retrieval.AnalysisEngines;
 
-import com.ontological.retrieval.DataTypes.Entity;
-import com.ontological.retrieval.DataTypes.Triplet;
-import com.ontological.retrieval.DataTypes.TripletField;
-import com.ontological.retrieval.DataTypes.TripletScore;
+import com.ontological.retrieval.DataTypes.*;
 import com.ontological.retrieval.Utilities.*;
 import de.tudarmstadt.ukp.dkpro.core.api.coref.type.CoreferenceLink;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
@@ -148,6 +145,12 @@ public class TripletsExtractor extends AbstractTripletsAnalyzer
                             if ( object.getBegin() >= nEntity.getBegin() && object.getEnd() <= nEntity.getEnd() ) {
                                 object.addAttribute( TripletField.AttributeType.NAMED_ENTITY, nEntity );
                                 System.out.println( "Matched named entity for object: " + nEntity.getCoveredText() );
+                            }
+                        }
+                        TripletDefinition definition = triplet.getDefinition();
+                        if ( definition != null ) {
+                            if ( nEntity.getBegin() >= definition.getBegin() && nEntity.getEnd() <= definition.getEnd() ) {
+                                definition.addNamedEntity( nEntity );
                             }
                         }
                     }

--- a/src/com/ontological/retrieval/DataTypes/Triplet.java
+++ b/src/com/ontological/retrieval/DataTypes/Triplet.java
@@ -1,5 +1,6 @@
 package com.ontological.retrieval.DataTypes;
 
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import org.apache.uima.cas.CASException;
@@ -89,6 +90,10 @@ public class Triplet extends Annotation
         return m_Relations.get( dep );
     }
 
+    public TripletDefinition getDefinition() {
+        return m_Definition;
+    }
+
     public List<String> getRelationTypes() {
         List<String> list = new ArrayList<>();
         list.addAll( m_Relations.keySet() );
@@ -172,6 +177,17 @@ public class Triplet extends Annotation
         }
         if ( m_Definition != null ) {
             System.out.println( "\tDefinition: " + m_Definition.getCoveredText() );
+            List<NamedEntity> namedEntities = m_Definition.getNamedEntities();
+            if ( namedEntities != null ) {
+                String nEntities = "";
+                for ( NamedEntity nEn : namedEntities ) {
+                    if ( !nEntities.isEmpty() ) {
+                        nEntities += ',';
+                    }
+                    nEntities += '{' + nEn.getType().getShortName() + ':' + nEn.getCoveredText() + '}';
+                }
+                System.out.println( "\t\tDefinition named entities: [" + nEntities + ']' );
+            }
         }
     }
 


### PR DESCRIPTION
Now, triplets definitions contains named entities. For this purpose was modified triplets extraction algorithm. Example of triplet, with attached named entities to triplet definition:

```
Sentence: By 1909, 1.34 million Angora goats were shorn in Texas.
[triplet] <goat>/NNS/ _:[{NSUBJ:shorn}] <>//
    $ Subject attributes: [Angora/NNP/]
    Definition: in Texas
        Definition named entities: [{Location:Texas}]

Sentence: Mohair production flourished in South Africa and the United States.
[triplet] <production>/NN/ _:[{NSUBJ:flourished}] <>//
    $ Subject attributes: [Mohair/NN/]
    Definition: in South Africa and the United States
        Definition named entities: [{Location:South Africa},{Location:United States}]
```
